### PR TITLE
Fix 'at' in GeofenceEvent.Detail

### DIFF
--- a/Samples/Models/GeofenceEvent.cs
+++ b/Samples/Models/GeofenceEvent.cs
@@ -17,7 +17,7 @@ namespace Samples.Models
 
         public string Text => this.Identifier;
         public string Detail => this.Entered
-            ? $"Entered on {this.Date:MMM d a\t h:mm tt}"
-            : $"Exited on {this.Date:MMM d a\t h:mm tt}";
+            ? $"Entered on {this.Date:MMM d 'at' h:mm tt}"
+            : $"Exited on {this.Date:MMM d 'at' h:mm tt}";
     }
 }


### PR DESCRIPTION
Noticed event log isn't displaying "at" correctly. `\\` or a verbatim string would also work.