### PR TITLE
Use Count > 0 instead of Any

### DIFF
--- a/Samples/Infrastructure/AbstractLogViewModel.cs
+++ b/Samples/Infrastructure/AbstractLogViewModel.cs
@@ -21,7 +21,7 @@ namespace Samples.Infrastructure
             this.Logs = new ObservableList<TItem>();
             this.hasLogs = this.Logs
                 .WhenCollectionChanged()
-                .Select(_ => this.Logs.Any())
+                .Select(_ => this.Logs.Count > 0)
                 .ToProperty(this, x => x.HasLogs);
 
             this.Load = ReactiveCommand.CreateFromTask(async () =>


### PR DESCRIPTION
When looking at the job log screen, I saw the error shown in the included screenshot.
Using `.Count` instead of `.Any` so it doesn't try to create an enumerator.

![Screenshot_20191219-110213](https://user-images.githubusercontent.com/6155690/71193842-6ecedc00-2250-11ea-81e0-8d42671d91bc.jpg)
