### PR TITLE
update to use Central Package Versioning

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,3 @@
+<Project>
+  <Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.0.79" />
+</Project>

--- a/Packages.props
+++ b/Packages.props
@@ -1,0 +1,53 @@
+<Project>
+
+  <PropertyGroup>
+    <LatestShinyBuild>2.0.0.2247</LatestShinyBuild>
+    <XamarinFormsVersion>4.8.0.1451</XamarinFormsVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Shiny.Core" Version="$(LatestShinyBuild)" />
+    <PackageReference Update="Shiny.Beacons" Version="$(LatestShinyBuild)" />
+    <PackageReference Update="Shiny.Beacons.Advertising" Version="$(LatestShinyBuild)-beta" />
+    <PackageReference Update="Shiny.BluetoothLE" Version="$(LatestShinyBuild)" />
+    <PackageReference Update="Shiny.BluetoothLE.Hosting" Version="$(LatestShinyBuild)-beta" />
+    <PackageReference Update="Shiny.DataSync" Version="$(LatestShinyBuild)" />
+    <PackageReference Update="Shiny.Integrations.Sqlite" Version="$(LatestShinyBuild)" />
+    <PackageReference Update="Shiny.Locations" Version="$(LatestShinyBuild)-beta" />
+    <PackageReference Update="Shiny.Locations.Sync" Version="$(LatestShinyBuild)" />
+    <PackageReference Update="Shiny.Logging.AppCenter" Version="$(LatestShinyBuild)" />
+    <PackageReference Update="Shiny.MediaSync" Version="$(LatestShinyBuild)-alpha" />
+    <PackageReference Update="Shiny.Net.Http" Version="$(LatestShinyBuild)" />
+    <PackageReference Update="Shiny.Nfc" Version="$(LatestShinyBuild)" />
+    <PackageReference Update="Shiny.Notifications" Version="$(LatestShinyBuild)" />
+    <PackageReference Update="Shiny.Push" Version="$(LatestShinyBuild)-beta" />
+    <PackageReference Update="Shiny.Push.AzureNotificationHubs" Version="$(LatestShinyBuild)-beta" />
+    <PackageReference Update="Shiny.Push.FirebaseMessaging" Version="$(LatestShinyBuild)-beta" />
+    <PackageReference Update="Shiny.Sensors" Version="$(LatestShinyBuild)" />
+    <PackageReference Update="Shiny.SpeechRecognition" Version="$(LatestShinyBuild)" />
+    <PackageReference Update="Shiny.TripTracker" Version="$(LatestShinyBuild)-beta" />
+    <PackageReference Update="Shiny.Vpn" Version="1.2.0.1812-alpha" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Bogus" Version="31.0.3" />
+    <PackageReference Update="Humanizer" Version="2.8.26" />
+    <PackageReference Update="Prism.DryIoc.Forms" Version="7.2.0.1422" />
+    <PackageReference Update="ReactiveUI.Fody" Version="11.5.35" />
+    <PackageReference Update="sqlite-net-pcl" Version="1.7.335" />
+    <PackageReference Update="XF.Material" Version="1.7.5" />
+    <PackageReference Update="Xamarin.Forms" Version="$(XamarinFormsVersion)" />
+    <PackageReference Update="Xamarin.Essentials" Version="1.5.3.2" />
+    <PackageReference Update="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.10" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="ZNetCS.AspNetCore.ResumingFileResults" Version="2.2.0" />
+    <PackageReference Update="Meadow.Foundation" Version="0.10.8" />
+    <PackageReference Update="Tizen.NET" Version="5.0.0.14562" ExcludeAssets="Runtime" />
+    <PackageReference Update="Tizen.NET.Sdk" Version="1.0.1" />
+    <PackageReference Update="Xamarin.Forms.Platform.WPF" Version="$(XamarinFormsVersion)" />
+    <PackageReference Update="Xamarin.Forms.Platform.GTK" Version="$(XamarinFormsVersion)" />
+  </ItemGroup>
+
+</Project>

--- a/Samples.Android/Samples.Android-Debug.csproj
+++ b/Samples.Android/Samples.Android-Debug.csproj
@@ -66,21 +66,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1451" />
-    <PackageReference Include="Xamarin.Essentials">
-      <Version>1.5.3.2</Version>
-    </PackageReference>
-      <!--
-        <PackageReference Include="Xamarin.Firebase.Messaging" Version="71.1740.4" />
-        <PackageReference Include="Xamarin.GooglePlayServices.Tasks" Version="71.1601.4" />
-
-        <PackageReference Include="Xamarin.Firebase.Datatransport" Version="117.0.5-preview02" />
-        <PackageReference Include="Xamarin.Firebase.Common" Version="119.3.0-preview02" />
-        <PackageReference Include="Xamarin.Firebase.Messaging" Version="120.1.7-preview02" />
-        <PackageReference Include="Xamarin.GooglePlayServices.Base" Version="117.2.1-preview02" />
-        <PackageReference Include="Xamarin.GooglePlayServices.Basement" Version="117.2.1-preview02" />
-        <PackageReference Include="Xamarin.GooglePlayServices.Tasks" Version="117.0.2-preview02" />
-        -->
+    <PackageReference Include="Xamarin.Forms" />
+    <PackageReference Include="Xamarin.Essentials" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MainActivity.cs" />

--- a/Samples.Android/Samples.Android.csproj
+++ b/Samples.Android/Samples.Android.csproj
@@ -58,18 +58,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Shiny.Core">
-      <Version>2.0.0.2170</Version>
-    </PackageReference>
-    <PackageReference Include="Xamarin.Essentials">
-      <Version>1.5.3.2</Version>
-    </PackageReference>
-    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1364" />
-    <!--<PackageReference Include="Xamarin.Firebase.Datatransport" Version="117.0.5-preview02" />
-    <PackageReference Include="Xamarin.Firebase.Common" Version="119.3.0-preview02" />
-    <PackageReference Include="Xamarin.Firebase.Messaging" Version="120.1.7-preview02" />
-    <PackageReference Include="Xamarin.GooglePlayServices.Basement" Version="117.2.1-preview02" />
-    <PackageReference Include="Xamarin.GooglePlayServices.Tasks" Version="117.0.2-preview02" />-->
+    <PackageReference Include="Shiny.Core" />
+    <PackageReference Include="Xamarin.Essentials" />
+    <PackageReference Include="Xamarin.Forms" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MainActivity.cs" />

--- a/Samples.Api/Samples.Api.csproj
+++ b/Samples.Api/Samples.Api.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="sqlite-net-pcl" Version="1.7.335" />
-    <PackageReference Include="ZNetCS.AspNetCore.ResumingFileResults" Version="2.2.0" />
+    <PackageReference Include="sqlite-net-pcl" />
+    <PackageReference Include="ZNetCS.AspNetCore.ResumingFileResults" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples.Meadow/Samples.Meadow-Debug.csproj
+++ b/Samples.Meadow/Samples.Meadow-Debug.csproj
@@ -1,10 +1,10 @@
-<Project Sdk="Meadow.Sdk/1.1">
+<Project Sdk="Meadow.Sdk">
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
     <OutputType>Exe</OutputType>
     <AssemblyName>App</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Meadow.Foundation" Version="0.10.8" />
+    <PackageReference Include="Meadow.Foundation" />
   </ItemGroup>
 </Project>

--- a/Samples.Meadow/Samples.Meadow.csproj
+++ b/Samples.Meadow/Samples.Meadow.csproj
@@ -1,10 +1,10 @@
-<Project Sdk="Meadow.Sdk/1.1">
+<Project Sdk="Meadow.Sdk">
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
     <OutputType>Exe</OutputType>
     <AssemblyName>App</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Meadow.Foundation" Version="0.10.8" />
+    <PackageReference Include="Meadow.Foundation" />
   </ItemGroup>
 </Project>

--- a/Samples.SqliteGenerator/Samples.SqliteGenerator.csproj
+++ b/Samples.SqliteGenerator/Samples.SqliteGenerator.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bogus" Version="31.0.2" />
-    <PackageReference Include="sqlite-net-pcl" Version="1.7.335" />
+    <PackageReference Include="Bogus" />
+    <PackageReference Include="sqlite-net-pcl" />
   </ItemGroup>
 
 </Project>

--- a/Samples.Tizen/Samples.Tizen.Mobile/Samples.Tizen.Mobile.csproj
+++ b/Samples.Tizen/Samples.Tizen.Mobile/Samples.Tizen.Mobile.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Tizen.NET.Sdk/1.0.3">
+﻿<Project Sdk="Tizen.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -30,9 +30,9 @@
     <ProjectReference Include="..\..\..\shiny\src\Shiny.Nfc\Shiny.Nfc.csproj" />
     <ProjectReference Include="..\..\..\shiny\src\Shiny.Push\Shiny.Push.csproj" />
   </ItemGroup>
-  
+
 
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.5.0.530" />
+    <PackageReference Include="Xamarin.Forms" />
   </ItemGroup>
 </Project>

--- a/Samples.UWP/Samples.UWP-Debug.csproj
+++ b/Samples.UWP/Samples.UWP-Debug.csproj
@@ -159,8 +159,8 @@
         </Page>
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Xamarin.Forms" Version="4.8.0.1451" />
-        <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.10" />
+        <PackageReference Include="Xamarin.Forms" />
+        <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\..\shiny\src\Shiny.Beacons.Abstractions\Shiny.Beacons.Abstractions.csproj">

--- a/Samples.UWP/Samples.UWP.csproj
+++ b/Samples.UWP/Samples.UWP.csproj
@@ -169,11 +169,9 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Essentials">
-      <Version>1.5.3.2</Version>
-    </PackageReference>
-    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1364" />
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.10" />
+    <PackageReference Include="Xamarin.Essentials" />
+    <PackageReference Include="Xamarin.Forms" />
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Samples\Samples.csproj">

--- a/Samples.iOS/Samples.iOS-Debug.csproj
+++ b/Samples.iOS/Samples.iOS-Debug.csproj
@@ -212,7 +212,7 @@
         <Reference Include="Xamarin.iOS" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Xamarin.Forms" Version="4.8.0.1451" />
+        <PackageReference Include="Xamarin.Forms" />
     </ItemGroup>
     <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
     <ItemGroup>

--- a/Samples.iOS/Samples.iOS.csproj
+++ b/Samples.iOS/Samples.iOS.csproj
@@ -184,13 +184,9 @@
     <Reference Include="Xamarin.iOS" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Shiny.Core">
-      <Version>2.0.0.2170</Version>
-    </PackageReference>
-    <PackageReference Include="Xamarin.Essentials">
-      <Version>1.5.3.2</Version>
-    </PackageReference>
-    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1364" />
+    <PackageReference Include="Shiny.Core" />
+    <PackageReference Include="Xamarin.Essentials" />
+    <PackageReference Include="Xamarin.Forms" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Samples\Samples.csproj">

--- a/Samples.macOS/Samples.macOS-Debug.csproj
+++ b/Samples.macOS/Samples.macOS-Debug.csproj
@@ -53,7 +53,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="Xamarin.Mac" />    
+    <Reference Include="Xamarin.Mac" />
     <Reference Include="Xamarin.Forms.Core">
       <HintPath>..\packages\Xamarin.Forms.4.5.0.282-pre4\lib\Xamarin.Mac\Xamarin.Forms.Core.dll</HintPath>
     </Reference>
@@ -99,8 +99,8 @@
     <Compile Include="AppDelegate.cs" />
   </ItemGroup>
     <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.5.0.356" />
-    <PackageReference Include="Prism.DryIoc.Forms" Version="7.2.0.1422" />
+    <PackageReference Include="Xamarin.Forms" />
+    <PackageReference Include="Prism.DryIoc.Forms" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Samples\Samples-Debug.csproj">

--- a/Samples/Samples-Debug.csproj
+++ b/Samples/Samples-Debug.csproj
@@ -14,12 +14,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Humanizer" Version="2.8.25" />
-        <PackageReference Include="Prism.DryIoc.Forms" Version="7.2.0.1422" />
-        <PackageReference Include="ReactiveUI.Fody" Version="11.5.35" />
-        <PackageReference Include="sqlite-net-pcl" Version="1.7.335" />
-        <PackageReference Include="Xamarin.Forms" Version="4.8.0.1451" />
-        <PackageReference Include="XF.Material" Version="1.7.4" />
+        <PackageReference Include="Humanizer" />
+        <PackageReference Include="Prism.DryIoc.Forms" />
+        <PackageReference Include="ReactiveUI.Fody" />
+        <PackageReference Include="sqlite-net-pcl" />
+        <PackageReference Include="Xamarin.Forms" />
+        <PackageReference Include="XF.Material" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Samples/Samples.csproj
+++ b/Samples/Samples.csproj
@@ -13,33 +13,33 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Humanizer" Version="2.8.25" />
-        <PackageReference Include="Prism.DryIoc.Forms" Version="7.2.0.1422" />
-        <PackageReference Include="ReactiveUI.Fody" Version="11.5.35" />
-        <PackageReference Include="Shiny.Beacons" Version="2.0.0.2170" />
-        <PackageReference Include="Shiny.Beacons.Advertising" Version="2.0.0.2170-beta" />
-        <PackageReference Include="Shiny.BluetoothLE" Version="2.0.0.2170" />
-        <PackageReference Include="Shiny.BluetoothLE.Hosting" Version="2.0.0.2170-beta" />
-        <PackageReference Include="Shiny.DataSync" Version="2.0.0.2170" />
-        <PackageReference Include="Shiny.Integrations.Sqlite" Version="2.0.0.2170" />
-        <PackageReference Include="Shiny.Locations" Version="2.0.0.2170" />
-        <PackageReference Include="Shiny.Locations.Sync" Version="2.0.0.2170" />
-        <PackageReference Include="Shiny.Logging.AppCenter" Version="2.0.0.2170" />
-        <PackageReference Include="Shiny.MediaSync" Version="2.0.0.2170-alpha" />
-        <PackageReference Include="Shiny.Net.Http" Version="2.0.0.2170" />
-        <PackageReference Include="Shiny.Nfc" Version="2.0.0.2170" />
-        <PackageReference Include="Shiny.Notifications" Version="2.0.0.2170" />
-        <PackageReference Include="Shiny.Push" Version="2.0.0.2170" />
-        <PackageReference Include="Shiny.Push.AzureNotificationHubs" Version="2.0.0.2170" />
-        <PackageReference Include="Shiny.Push.FirebaseMessaging" Version="2.0.0.2170" />
-        <PackageReference Include="Shiny.Sensors" Version="2.0.0.2170" />
-        <PackageReference Include="Shiny.SpeechRecognition" Version="2.0.0.2170" />
-        <PackageReference Include="Shiny.TripTracker" Version="2.0.0.2170-beta" />
-        <PackageReference Include="Shiny.Vpn" Version="1.2.0.1812-alpha" />
-        <PackageReference Include="sqlite-net-pcl" Version="1.7.335" />
-        <PackageReference Include="Xamarin.Essentials" Version="1.5.3.2" />
-        <PackageReference Include="Xamarin.Forms" Version="4.8.0.1364" />
-        <PackageReference Include="XF.Material" Version="1.7.0" />
+        <PackageReference Include="Humanizer" />
+        <PackageReference Include="Prism.DryIoc.Forms" />
+        <PackageReference Include="ReactiveUI.Fody" />
+        <PackageReference Include="Shiny.Beacons" />
+        <PackageReference Include="Shiny.Beacons.Advertising" />
+        <PackageReference Include="Shiny.BluetoothLE" />
+        <PackageReference Include="Shiny.BluetoothLE.Hosting" />
+        <PackageReference Include="Shiny.DataSync" />
+        <PackageReference Include="Shiny.Integrations.Sqlite" />
+        <PackageReference Include="Shiny.Locations" />
+        <PackageReference Include="Shiny.Locations.Sync" />
+        <PackageReference Include="Shiny.Logging.AppCenter" />
+        <PackageReference Include="Shiny.MediaSync" />
+        <PackageReference Include="Shiny.Net.Http" />
+        <PackageReference Include="Shiny.Nfc" />
+        <PackageReference Include="Shiny.Notifications" />
+        <PackageReference Include="Shiny.Push" />
+        <PackageReference Include="Shiny.Push.AzureNotificationHubs" />
+        <PackageReference Include="Shiny.Push.FirebaseMessaging" />
+        <PackageReference Include="Shiny.Sensors" />
+        <PackageReference Include="Shiny.SpeechRecognition" />
+        <PackageReference Include="Shiny.TripTracker" />
+        <PackageReference Include="Shiny.Vpn" />
+        <PackageReference Include="sqlite-net-pcl" />
+        <PackageReference Include="Xamarin.Essentials" />
+        <PackageReference Include="Xamarin.Forms" />
+        <PackageReference Include="XF.Material" />
     </ItemGroup>
 
     <ItemGroup>

--- a/experiments/Samples.Gtk/Samples.Gtk.csproj
+++ b/experiments/Samples.Gtk/Samples.Gtk.csproj
@@ -71,9 +71,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms.Platform.GTK">
-      <Version>3.5.0.169047</Version>
-    </PackageReference>
+    <PackageReference Include="Xamarin.Forms.Platform.GTK" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Acr.Core\Acr.Core.csproj">

--- a/experiments/Samples.Tizen/Samples.Tizen.csproj
+++ b/experiments/Samples.Tizen/Samples.Tizen.csproj
@@ -20,11 +20,9 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Tizen.NET" Version="5.0.0.14562">
-      <ExcludeAssets>Runtime</ExcludeAssets>
-    </PackageReference>
-    <PackageReference Include="Tizen.NET.Sdk" Version="1.0.1" />
-    <PackageReference Include="Xamarin.Forms" Version="3.5.0.169047" />
+    <PackageReference Include="Tizen.NET" />
+    <PackageReference Include="Tizen.NET.Sdk" />
+    <PackageReference Include="Xamarin.Forms" />
   </ItemGroup>
 
 

--- a/experiments/Samples.Wpf/Samples.Wpf.csproj
+++ b/experiments/Samples.Wpf/Samples.Wpf.csproj
@@ -101,9 +101,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms.Platform.WPF">
-      <Version>3.5.0.169047</Version>
-    </PackageReference>
+    <PackageReference Include="Xamarin.Forms.Platform.WPF" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/experiments/Samples.macOS/Samples.macOS.csproj
+++ b/experiments/Samples.macOS/Samples.macOS.csproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\Xamarin.Forms.3.4.0.1008975\build\Xamarin.Forms.props" Condition="Exists('..\..\packages\Xamarin.Forms.3.4.0.1008975\build\Xamarin.Forms.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -61,7 +60,7 @@
     <Reference Include="Xamarin.Mac" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="3.5.0.169047" />
+    <PackageReference Include="Xamarin.Forms" />
   </ItemGroup>
   <ItemGroup>
     <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Contents.json" />
@@ -118,5 +117,4 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" />
-  <Import Project="..\..\packages\Xamarin.Forms.3.4.0.1008975\build\Xamarin.Forms.targets" Condition="Exists('..\..\packages\Xamarin.Forms.3.4.0.1008975\build\Xamarin.Forms.targets')" />
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "msbuild-sdks": {
+    "Meadow.Sdk": "1.1.0",
+    "Tizen.NET.Sdk": "1.0.9",
+    "Microsoft.Build.CentralPackageVersions": "2.0.79"
+  }
+}


### PR DESCRIPTION
# Description

Updates sample to use Central Package Versioning to make package management easier to deal with and keep dependencies in sync across the entire repo. 

Shiny & Xamarin.Forms packages can generally be updated by updating the property in Packages.props. **note** Shiny packages that are in beta will need the `-beta` appended to the version in Packages.props